### PR TITLE
Fix withTheme return type for React 19

### DIFF
--- a/packages/styled-components/src/hoc/withTheme.tsx
+++ b/packages/styled-components/src/hoc/withTheme.tsx
@@ -5,7 +5,17 @@ import determineTheme from '../utils/determineTheme';
 import getComponentName from '../utils/getComponentName';
 import hoist from '../utils/hoist';
 
-export default function withTheme<T extends AnyComponent>(Component: T) {
+export default function withTheme<T extends AnyComponent>(
+  Component: T
+): ReturnType<
+  typeof hoist<
+    React.ForwardRefExoticComponent<
+      React.PropsWithoutRef<React.JSX.LibraryManagedAttributes<T, ExecutionProps>> &
+        React.RefAttributes<T>
+    >,
+    T
+  >
+> {
   const WithTheme = React.forwardRef<T, React.JSX.LibraryManagedAttributes<T, ExecutionProps>>(
     (props, ref) => {
       const theme = React.useContext(ThemeContext);


### PR DESCRIPTION
Resolves https://github.com/styled-components/styled-components/issues/4359

The generated types differ as follows:

before this PR
<img width="919" alt="Screenshot 2024-10-09 at 12 07 42" src="https://github.com/user-attachments/assets/fee0851a-fc40-4b16-824e-c99f3e041135">

after this PR

<img width="889" alt="Screenshot 2024-10-09 at 12 07 16" src="https://github.com/user-attachments/assets/bca084d4-118e-482c-bab3-04a0f68b41fc">
